### PR TITLE
Added Docusaurus Plugin for Google Analytics

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -98,17 +98,16 @@ module.exports = {
       ],
       copyright: `Copyright © ${new Date().getFullYear()} moja global.`,
     },
-    image: "https://community.moja.global/img/logo.png",
+    image: 'https://community.moja.global/img/logo.png',
     metadatas: [
-      { name: "twitter:card", content: "summary_large_image" },
+      { name: 'twitter:card', content: 'summary_large_image' },
       {
-        name: "twitter:image",
-        content:
-          "https://community.moja.global/img/logo.png",
+        name: 'twitter:image',
+        content: 'https://community.moja.global/img/logo.png',
       },
-      { name: "twitter:title", content: "Moja Global Community" },
+      { name: 'twitter:title', content: 'Moja Global Community' },
       {
-        name: "twitter:description",
+        name: 'twitter:description',
         content: "Learn about moja global's projects and join our ever-growing community",
       },
     ],
@@ -117,6 +116,10 @@ module.exports = {
     [
       '@docusaurus/preset-classic',
       {
+        googleAnalytics: {
+          trackingID: 'UA-195907568-1',
+          anonymizeIP: true,
+        },
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.


### PR DESCRIPTION
## Description

Added Docusaurus Plugin for Google Analytics in `docusaurus.config.js` file with `trackingID: UA-195907568-1`
Since `@docusaurus/preset-classic` is already installed, we don't need to install `@docusaurus/plugin-google-analytics`

Fixes #77 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality).

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
