### PR TITLE
Issue #126 Fixed redirection of the contributing guidelines page.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -180,7 +180,7 @@ module.exports = {
             },
             {
               label: 'Contributing guidelines',
-              href: '/community/contributing-guidelines',
+              href: '/community/contributing',
             }
           ],
         },


### PR DESCRIPTION
## Description

The redirecting link for Contributing Guidelines is changed to community.moja.global/community/contributing

Fixes #126 

## Type of change

- Bug fix (non-breaking change which fixes an issue).

