### PR TITLE
DOCS: Updated broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Before setting up the project make sure the LTS (Long Term Support) version of N
 
 ## Contribution Guides
 
-- [How to write and publish a blog](https://community.moja.global/community/contributing#writing-new-blogs)
-- [How to write and publish documentation](https://community.moja.global/community/contributing#adding-new-documentation)
+- [How to write and publish a blog](https://community.moja.global/community/community-website-contributions#writing-new-blogs)
+- [How to write and publish documentation](https://community.moja.global/community/community-website-contributions#adding-new-documentation)
 - [How to add meetings](https://github.com/moja-global/community-website/blob/main/website/meetings.md)
 
 ## How to Get Involved?


### PR DESCRIPTION
## Description

Fixes the broken `Contribution Guides` section links in README.md.

Fixes #157 

## Type of change

- Bug fix (non-breaking change which fixes an issue).