### PR TITLE
remove PWA score result from Lighthouse Workflow

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -51,7 +51,6 @@ jobs:
                 `| ${score(result.accessibility)} Accessibility | ${result.accessibility} |`,
                 `| ${score(result['best-practices'])} Best practices | ${result['best-practices']} |`,
                 `| ${score(result.seo)} SEO | ${result.seo} |`,
-                `| ${score(result.pwa)} PWA | ${result.pwa} |`,
                 ' ',
                 `*Lighthouse ran on [${Object.keys(links)[0]}](${Object.keys(links)[0]})*`
             ].join('\n')


### PR DESCRIPTION
# Update lighthouse-ci workflow

## Description

The `community-website` project at its present scope is not configured to work as a PWA. We can remove the PWA Score section from the comment generated on successive PR when the workflow runs to provide more clarity upon lighthouse scores.

The Lighthouse Report's PWA section is as below:
![image](https://user-images.githubusercontent.com/47717492/148884208-b6b4ce9f-1110-4d7e-84d8-08f5ca9c5fa7.png)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding tests.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.
