### PR TITLE
Sidebar visibility for middle screen sizes

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -264,17 +264,17 @@ html[data-theme='dark'] .stats-item p:hover {
 }
 
 @media only screen and (max-width: 1279px) {
-  .navbar__toggle {
-    display: inherit;
-  }
-  .navbar__item {
+  .navbar__inner .navbar__brand .navbar__title {
     display: none;
   }
-  .navbar__search-input {
-    width: 9rem;
+
+  .navbar__inner .navbar__items--right .dropdown span span {
+    display: none;
   }
-  .displayOnlyInLargeViewport_node_modules-\@docusaurus-theme-classic-lib-next-theme-Navbar- {
-    display: none !important;
+
+  .navbar__inner .navbar__items--right .DocSearch-Button .DocSearch-Button-Placeholder,
+  .navbar__inner .navbar__items--right .DocSearch-Button .DocSearch-Button-Keys {
+    display: none;
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Anushka Chauhan <anushkachauhan1503@gmail.com>

## Description

#### Fixes #217

The sidebar (having navbar items) was not visible for screen size: 997px -1280px.

The problem here is that:
* By default the navbar becomes toggleable when `screen-size = 996px and below`.
* Currently, we have hidden navbar items and shown the toggle button using custom CSS.
* But the navbar-sidebar (with menu items) is not added to the DOM until default screen break occurs.

My solution:
* Remove the custom CSS and follow default screen breaks.
	
**Before:** The UI becomes congested at `screen-size: 997px`

![image](https://user-images.githubusercontent.com/59930625/157067438-dd69b6c5-17cd-4a10-b520-c6b00fadd46c.png)

**After:** With small CSS changes, we can make it more clean

![image](https://user-images.githubusercontent.com/59930625/157066854-1410d53b-25db-465a-91d8-81ca6b690dc3.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

By running it in localhost using guidelines from [CONTRIBUTING.md](https://github.com/moja-global/community-website/blob/main/CONTRIBUTING.md#how-to-set-up-the-community-website-locally).

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding tests.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.
