### PR TITLE
a sticky navbar is better for navigation imo

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -11,7 +11,7 @@ module.exports = {
   projectName: 'Community Website', // Usually your repo name.
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'es'],
+    locales: ['en'],
   },
   themeConfig: {
     algolia: {
@@ -52,10 +52,7 @@ module.exports = {
         srcDark: 'img/logo-light.png',
       },
       items: [
-        {
-          type: 'localeDropdown',
-          position: 'right',
-        },
+       
         {
           href: 'https://github.com/moja-global',
           label: 'GitHub',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -45,7 +45,7 @@ module.exports = {
     },
     navbar: {
       title: 'Community',
-      hideOnScroll: true,
+      hideOnScroll: false,
       logo: {
         alt: 'moja global Logo',
         src: 'img/logo.png',


### PR DESCRIPTION
Issue: The navbar used to hide on the community website whenever I scrolled down. I found it counter productive for navigating the website so I suggest that we keep the navbar sticky. 
Signed-off-by: Arya Bhosale <arya2001bhosale@gmail.com>
@chicken-biryani  what do you think?