### PR TITLE
Fixed broken link to FAQs on the community website home page

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -162,7 +162,7 @@ module.exports = {
             },
             {
               label: 'FAQs',
-              href: 'https://docs.moja.global/en/latest/faq.html',
+              href: 'https://docs.moja.global/en/add_instructions_gdal/faq.html',
             },
           ],
         },


### PR DESCRIPTION
## Description

Fixed broken link to FAQs on the home page of community website

Fixes # (https://github.com/moja-global/community-website/issues/384)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change requires a documentation update.