### PR TITLE
Corrected grammatical mistakes in Code of Conduct

### DIFF
--- a/website/community/Code-of-Conduct.mdx
+++ b/website/community/Code-of-Conduct.mdx
@@ -6,7 +6,7 @@ title: Code of Conduct
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
+contributors and maintainers pledge to make participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socio-economic status, nationality, personal
@@ -42,7 +42,7 @@ response to any instances of unacceptable behavior.
 
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
+that are not aligned with this Code of Conduct, or to ban temporarily or
 permanently any contributor for other behaviors that they deem inappropriate,
 threatening, offensive, or harmful.
 
@@ -61,7 +61,7 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team at guy@moja.global. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
+obligated to maintain confidentiality concerning the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good


### PR DESCRIPTION
Signed-off-by: Arya Gupta <arya.gupta99999@gmail.com>

## Description

The code of conduct previously contained grammatical errors.

Fixes # (issue)
https://github.com/moja-global/community-website/issues/423

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] This change requires a documentation update.
